### PR TITLE
Use try catch to exit when joblib.load overflows memory

### DIFF
--- a/model/framework/code/main.py
+++ b/model/framework/code/main.py
@@ -27,16 +27,18 @@ def my_model(smiles,model):
     preds = []
     try:
         syba_model = joblib.load(model)
+        for smi in smiles:
+            mol = Chem.MolFromSmiles(smi)
+            if mol is None:
+                preds.append(None)
+            else:
+                preds.append(syba_model.predict(mol=mol))
+        return preds
     except Exception as e:
         print(f"Error occurred while loading the model: {str(e)}")
+        sys.exit(0)
 
-    for smi in smiles:
-        mol = Chem.MolFromSmiles(smi)
-        if mol is None:
-            preds.append(None)
-        else:
-            preds.append(syba_model.predict(mol=mol))
-    return preds
+   
 
 outputs = my_model(smiles_list, model_path)
 

--- a/model/framework/code/main.py
+++ b/model/framework/code/main.py
@@ -22,11 +22,14 @@ with open(input_file, "r") as f:
     reader = csv.reader(f)
     next(reader)  # skip header
     smiles_list = [r[0] for r in reader]
-        
-        
-def my_model(smiles, model):
+
+def my_model(smiles,model):
     preds = []
-    syba_model = joblib.load(model)
+    try:
+        syba_model = joblib.load(model)
+    except Exception as e:
+        print(f"Error occurred while loading the model: {str(e)}")
+
     for smi in smiles:
         mol = Chem.MolFromSmiles(smi)
         if mol is None:
@@ -34,8 +37,6 @@ def my_model(smiles, model):
         else:
             preds.append(syba_model.predict(mol=mol))
     return preds
-
-#run model
 
 outputs = my_model(smiles_list, model_path)
 
@@ -47,6 +48,7 @@ assert input_len == output_len
 # write output in a .csv file
 with open(output_file, "w") as f:
     writer = csv.writer(f)
-    writer.writerow(["value"])  # header
+    writer.writerow(["sy_sa"])  # header
     for o in outputs:
         writer.writerow([o])
+


### PR DESCRIPTION
Added  in the  try catch in the model since joblib.load() may overflow the memory and cause silent errors. The error may also be platform specific more so in the docker environment.