### PR TITLE
Changed the syba installation and tracked the zip file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
 *.joblib filter=lfs diff=lfs merge=lfs -text
-*.tar.bz2 filter=lfs diff=lfs merge=lfs -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 *.joblib filter=lfs diff=lfs merge=lfs -text
-*.zip filter=lfs diff=lfs merge=lfs -text
+*.tar.bz2 filter=lfs diff=lfs merge=lfs -text

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,7 @@ MAINTAINER ersilia
 
 RUN pip install rdkit==2023.03.1
 RUN pip install joblib
-RUN unzip model/checkpoints/syba-master.zip && cd syba-master
-RUN python setup.py install
-RUN rm -rf syba-master
+RUN conda install model/checkpoints/syba-1.0.2.alpha-py_0.tar.bz2
 
 WORKDIR /repo
 COPY ./repo

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ MAINTAINER ersilia
 
 RUN pip install rdkit==2023.03.1
 RUN pip install joblib
-RUN conda install model/checkpoints/syba-1.0.2.alpha-py_0.tar.bz2
-
+RUN wget https://anaconda.org/LICH/syba/1.0.2.alpha/download/noarch/syba-1.0.2.alpha-py_0.tar.bz2
+RUN conda install syba-1.0.2.alpha-py_0.tar.bz2
+RUN rm -rf syba-1.0.2.alpha-py_0.tar.bz2
 WORKDIR /repo
 COPY ./repo

--- a/model/checkpoints/syba-1.0.2.alpha-py_0.tar.bz2
+++ b/model/checkpoints/syba-1.0.2.alpha-py_0.tar.bz2
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d47bd80224516c9c6e917685d65932dd610b85d68c9bc2b075bbdc4789b525e4
-size 142251017

--- a/model/checkpoints/syba-1.0.2.alpha-py_0.tar.bz2
+++ b/model/checkpoints/syba-1.0.2.alpha-py_0.tar.bz2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d47bd80224516c9c6e917685d65932dd610b85d68c9bc2b075bbdc4789b525e4
+size 142251017

--- a/model/checkpoints/syba-master.zip
+++ b/model/checkpoints/syba-master.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1202508dc96a59fd8d9fac3af06befe17e32e9bc0bffc4fe72a59c4b33c60c56
-size 50756533


### PR DESCRIPTION
@GemmaTuron , The  workflow failed because  the `unzip` command was not found  in the ubuntu workflow 
```
#5 110.3 WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
#5 110.3 /tmp/ersilia-f8894agd/script.sh: line 7: unzip: command not found
#5 110.3 /tmp/ersilia-f8894agd/script.sh: line 8: cd: syba-master: No such file or directory
```
The default ubuntu environment for  Colab has the `zip` package  installed but the default distros don't have this package by default. I am not zipping or unzipping . I am able to fetch 
[colab_eos7pw8_fetch (2).log](https://github.com/ersilia-os/eos7pw8/files/12047753/colab_eos7pw8_fetch.2.log)
